### PR TITLE
Add workflow schedule trigger

### DIFF
--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -1,5 +1,7 @@
 name: module-ci
 on:
+  schedule:
+    - cron: "0 0 * * 0" # weekly on Sunday at 00:00
   push:
     branches:
       - main
@@ -17,6 +19,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
       pull-requests: read
     secrets:
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}


### PR DESCRIPTION
This PR adds a `schedule` trigger to the "module-ci" workflow, ensuring it runs automatically once a week. Failure handling and additional logic, such as how to manage failures in the scheduled workflow, are implemented in the reusable workflow at <https://github.com/cloudeteer/terraform-governance/pull/36>.