### PR TITLE
update module workflows (cloudeteer/terraform-governance#58)

### DIFF
--- a/.github/workflows/module-manage-github.yaml
+++ b/.github/workflows/module-manage-github.yaml
@@ -14,5 +14,8 @@ on:
 
 jobs:
   module-manage-github:
-    uses: cloudeteer/terraform-governance/.github/workflows/module-github-project.yaml@main
+    uses: cloudeteer/terraform-governance/.github/workflows/module-github.yaml@main
+    permissions:
+      contents: write
+      pull-requests: read
     secrets: inherit


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This pull request includes changes to the GitHub Actions workflows to streamline and improve the CI/CD process. The most important changes involve modifications to the triggers for workflows and the addition of a new workflow for managing GitHub modules.

Changes to workflow triggers:

* [`.github/workflows/module-ci.yaml`](diffhunk://#diff-55f167f3b832601d0da7ca3351b9bf4bf077a5c7f9b4b6abea6cb0e5e84c41b9L6-L15): Removed the `push` trigger for the `main` branch and the `labeled` and `unlabeled` triggers for pull requests.

Addition of a new workflow:

* [`.github/workflows/module-manage-github.yaml`](diffhunk://#diff-769b2e3dd62779ac8e2b98dc3c0088ce4441f9ce25f1dc77eb416e2ece71f593R1-R18): Added a new workflow named `module-manage-github` that triggers on `push` to the `main` branch, on issue creation, and on specific pull request events (`opened`, `labeled`, `unlabeled`).


## PR Checklist
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have checked for a proper tag for this PR: `breaking-change`, `feature`, `fix`, `other`, `ignore-release`
- [x] I have used a **meaningful** PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

relates to cloudeteer/terraform-governance#58

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None.
